### PR TITLE
convrting keys and args to strings to comply with redis

### DIFF
--- a/mockredis/script.py
+++ b/mockredis/script.py
@@ -17,8 +17,16 @@ class Script(object):
 
         if not client.script_exists(self.sha)[0]:
             self.sha = client.script_load(self.script)
-
-        return self._execute_lua(keys, args, client)
+        
+        str_keys = []
+        for key in keys:
+            str_keys.append(str(key))
+        
+        str_args = []
+        for arg in args:
+            str_args.append(str(arg))
+            
+        return self._execute_lua(str_keys, str_args, client)
 
     def _execute_lua(self, keys, args, client):
         """


### PR DESCRIPTION
When mock redis passes args/keys to lua scripts it doesn't convert them to strings first, but lua in redis always receives strings as arguments.
This causes type error some of our lua scripts.